### PR TITLE
fix: iOS and macOS compilation

### DIFF
--- a/ellekit/API/MobileSubstrate.swift
+++ b/ellekit/API/MobileSubstrate.swift
@@ -18,27 +18,24 @@ public func MSFindSymbol(_ image: UnsafeRawPointer?, _ name: UnsafeRawPointer?) 
     guard let name else { return nil }
     
     if let image {
-        if #available(iOS 14.0, *) {
-            #if canImport(Darwin) && !os(macOS)
-            if _dyld_shared_cache_contains_path(_dyld_get_image_name(image)), let symbol = try? ellekit.findPrivateSymbol(image: image, symbol: String(cString: name.assumingMemoryBound(to: CChar.self))) {
-                return .init(symbol)
-            }
-            #endif
+        #if os(macOS)
+        if let symbol = try? ellekit.findSymbol(image: image, symbol: String(cString: name.assumingMemoryBound(to: CChar.self))) {
+            return .init(symbol)
         }
+        #else
         if let symbol = try? ellekit.findSymbol(image: image, symbol: String(cString: name.assumingMemoryBound(to: CChar.self))) {
             return .init(symbol)
         } else if let symbol = try? ellekit.findPrivateSymbol(image: image, symbol: String(cString: name.assumingMemoryBound(to: CChar.self))) {
             return .init(symbol)
         }
+        #endif
     } else {
         for img in 0..<_dyld_image_count() {
             if let hdr = _dyld_get_image_header(img) {
-                if #available(iOS 14.0, *) {
-                    #if canImport(Darwin) && !os(macOS)
+                if #available(iOS 14.0, macOS 11.0, *) {
                     if _dyld_shared_cache_contains_path(_dyld_get_image_name(img)), let symbol = try? ellekit.findPrivateSymbol(image: hdr, symbol: String(cString: name.assumingMemoryBound(to: CChar.self))) {
                         return .init(symbol)
                     }
-                    #endif
                 }
                 if let symbol = try? ellekit.findSymbol(image: hdr, symbol: String(cString: name.assumingMemoryBound(to: CChar.self))) {
                     return .init(symbol)

--- a/injector/injector.c
+++ b/injector/injector.c
@@ -256,9 +256,11 @@ static void tweaks_iterate() {
             
             bool ret = tweak_needinject(plist);
             if (ret) {
+                #if !TARGET_OS_OSX
                 if (!access(OLDABI_PATH, F_OK)) {
                     dlopen(OLDABI_PATH, RTLD_NOW);
                 }
+                #endif
                 
                 dlopen(full_path, RTLD_NOW);
                 


### PR DESCRIPTION
Not sure why https://github.com/evelyneee/ellekit/pull/15/files#diff-bd183c8923bd50627d9c779cf972128bfaf9096968f1d0b5bd41a7b1556a655cL21-L26 was changed (bad copy in #14?) but this doesn't make sense as `image` is a pointer, not a `UInt32`. Reverted that section to the old behavior

For https://github.com/evelyneee/ellekit/pull/15/files#diff-bd183c8923bd50627d9c779cf972128bfaf9096968f1d0b5bd41a7b1556a655cR35, changed it to check for macOS 11 availability instead of unconditionally disabling it on macOS

and then CI failed so `OLDABI_PATH` was gated behind `ifdef`