### PR TITLE
Add EKHookMemoryRaw, fix compilation with Xcode 15.3

### DIFF
--- a/ellekitc/include/ellekit.h
+++ b/ellekitc/include/ellekit.h
@@ -92,6 +92,7 @@ extern kern_return_t
 mach_vm_remap(vm_map_t target_task, mach_vm_address_t *target_address, mach_vm_size_t size, mach_vm_offset_t mask, int flags, vm_map_t src_task, mach_vm_address_t src_address, boolean_t copy, vm_prot_t *cur_protection, vm_prot_t *max_protection, vm_inherit_t inheritance);
 
 extern void manual_memcpy(void *restrict dest, const void *src, size_t len);
+extern kern_return_t (*EKHookMemoryRaw)(void *target, const void *data, size_t size);
 
 #pragma pack(4)
 typedef struct {

--- a/ellekitc/include/ellekit.h
+++ b/ellekitc/include/ellekit.h
@@ -12,7 +12,11 @@
 
 #import "sandbox.h"
 
+#if __has_include(<xpc/xpc.h>)
+#import <xpc/xpc.h>
+#else
 #import "xpc.h"
+#endif
 
 struct sCSRange {
    unsigned long long location;


### PR DESCRIPTION
This adds the `EKHookMemoryRaw` function pointer that jailbreaks are able to set to intercept memory hooks. I have also rewritten the old implementation in C (as it was just Swift code calling C functions anyways) and added some improvements to it, such as checking if remapping is even neccessary to write to it.

In the future it would make sense to centralize this API further to also cover any writes of to-be-made-executable data (right now there are some places in ellekit that allocate memory, write to it and then set it as executable), which would also allow a jailbreak to handle something like page signing, but for now this API is enough for Dopamine to intercept all hooks of DSC pages to fix spinlock panics.

Additionally, this also fixes compilation on Xcode 15.3 which was broken due to Apple adding XPC headers to the iOS sdk, because I sure as hell didn't want to install an older Xcode just to compile ellekit :P.