### PR TITLE
Update pac.c: Add include for stdlib.h

### DIFF
--- a/loader/pac.c
+++ b/loader/pac.c
@@ -2,8 +2,8 @@
 // This file is licensed under the BSD-3 Clause License
 // Copyright 2022 © ElleKit Team
 
-#include <stdlib.h>
 #include "pac.h"
+#include <stdlib.h>
 #include <ptrauth.h>
 #include <mach/arm/thread_status.h>
 

--- a/loader/pac.c
+++ b/loader/pac.c
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-3 Clause License
 // Copyright 2022 © ElleKit Team
 
+#include <stdlib.h>
 #include "pac.h"
 #include <ptrauth.h>
 #include <mach/arm/thread_status.h>


### PR DESCRIPTION
Fails to compile on macOS 15.5 and macOS 26 DB2.

loader/pac.c is missing #include <stdlib.h>
